### PR TITLE
Make app bar transparent

### DIFF
--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -5,7 +5,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
+    android:background="@android:color/transparent"
     android:fitsSystemWindows="true"
+    app:elevation="0dp"
     app:liftOnScroll="false">
 
     <com.google.android.material.appbar.MaterialToolbar

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -52,7 +52,7 @@
     </style>
 
     <style name="Widget.AppTheme.Toolbar" parent="Widget.Material3.Toolbar">
-        <item name="android:background">?attr/colorSurface</item>
+        <item name="android:background">@android:color/transparent</item>
         <item name="titleTextColor">?attr/colorOnSurface</item>
         <item name="subtitleTextColor">?attr/colorOnSurfaceVariant</item>
         <item name="titleTextAppearance">@style/TextAppearance.Material3.TitleLarge</item>


### PR DESCRIPTION
Drop the toolbar background fill and AppBarLayout elevation so the app bar blends into the activity surface instead of rendering its own tile and shadow.